### PR TITLE
TASK-3962 Port: Multiuser support from mcpi-e package

### DIFF
--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -277,6 +277,11 @@ class Minecraft:
         """Get the entity id of the named player => id"""
         return self.conn.sendReceive(b"world.getPlayerId", name)
 
+    def getPlayerNames(self):
+        """Get the names of all currently connected players => [str]"""
+        ids = self.conn.sendReceive(b"world.getPlayerIds")
+        return [tuple.split(":")[0] for tuple in ids.split("|")]
+
     def saveCheckpoint(self):
         """Save a checkpoint that can be used for restoring the world"""
         self.conn.send(b"world.checkpoint.save")

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -299,13 +299,20 @@ class Minecraft:
         self.conn.send(b"world.setting", setting, 1 if bool(status) else 0)
 
     def setPlayer(self, name):
-        """Set the current player"""
-        return self.conn.sendReceive(b"setPlayer", name)
+        """Set the current player => bool"""
+        if self.conn.sendReceive(b"setPlayer", name):
+            self.playerName = name
+            return True
+        else:
+            return False
 
     def getPlayerName(self):
-        """Get the name of the current player => str"""
-        playerName = self.conn.sendReceive(b"getPlayer")
-        return None if playerName == "(none)" else playerName
+        """Get the name of the previously set / currently attached player => str"""
+        if self.playerName:
+            return self.playerName
+        else:
+            playerName = self.conn.sendReceive(b"getPlayer")
+            return None if playerName == "(none)" else playerName
 
     @staticmethod
     def create(address="localhost", port=4711, playerName=[], debug=False):

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -130,31 +130,31 @@ class Entity:
 
 class CmdPlayer(CmdPositioner):
     """Methods for the host (Raspberry Pi) player"""
-    def __init__(self, connection, playerId):
+    def __init__(self, connection, playerName):
         CmdPositioner.__init__(self, connection,  b"player")
         self.conn = connection
-        self.playerId = playerId
+        self.playerName = playerName
 
     def getPos(self):
-        return CmdPositioner.getPos(self, self.playerId)
+        return CmdPositioner.getPos(self, self.playerName)
     def setPos(self, *args):
-        return CmdPositioner.setPos(self, self.playerId, args)
+        return CmdPositioner.setPos(self, self.playerName, args)
     def getTilePos(self):
-        return CmdPositioner.getTilePos(self, self.playerId)
+        return CmdPositioner.getTilePos(self, self.playerName)
     def setTilePos(self, *args):
-        return CmdPositioner.setTilePos(self, self.playerId, args)
+        return CmdPositioner.setTilePos(self, self.playerName, args)
     def setDirection(self, *args):
-        return CmdPositioner.setDirection(self, self.playerId, args)
+        return CmdPositioner.setDirection(self, self.playerName, args)
     def getDirection(self):
-        return CmdPositioner.getDirection(self, self.playerId)
+        return CmdPositioner.getDirection(self, self.playerName)
     def setRotation(self, yaw):
-        return CmdPositioner.setRotation(self,self.playerId, yaw)
+        return CmdPositioner.setRotation(self,self.playerName, yaw)
     def getRotation(self):
-        return CmdPositioner.getRotation(self, self.playerId)
+        return CmdPositioner.getRotation(self, self.playerName)
     def setPitch(self, pitch):
-        return CmdPositioner.setPitch(self, self.playerId, pitch)
+        return CmdPositioner.setPitch(self, self.playerName, pitch)
     def getPitch(self):
-        return CmdPositioner.getPitch(self, self.playerId)
+        return CmdPositioner.getPitch(self, self.playerName)
 
 class CmdCamera:
     def __init__(self, connection):
@@ -207,14 +207,14 @@ class CmdEvents:
 
 class Minecraft:
     """The main class to interact with a running instance of Minecraft Pi."""
-    def __init__(self, connection, playerId):
+    def __init__(self, connection, playerName):
         self.conn = connection
 
         self.camera = CmdCamera(connection)
         self.entity = CmdEntity(connection)
-        self.player = CmdPlayer(connection, playerId)
+        self.player = CmdPlayer(connection, playerName)
         self.events = CmdEvents(connection)
-        self.playerId = playerId
+        self.playerName = playerName
 
     def getBlock(self, *args):
         """Get block (x,y,z) => id:int"""
@@ -297,7 +297,7 @@ class Minecraft:
         return self.conn.sendReceive(b"setPlayer", name)
 
     @staticmethod
-    def create(address="localhost", port=4711, playerName="", debug=False):
+    def create(address="localhost", port=4711, playerName=[], debug=False):
         if "JRP_API_HOST" in os.environ:
             address = os.environ["JRP_API_HOST"]
         if "JRP_API_PORT" in os.environ:
@@ -306,12 +306,7 @@ class Minecraft:
             except ValueError:
                 pass
 
-        conn = Connection(address, port, debug)
-        if playerName != "":
-            playerId = conn.sendReceive(b"world.getPlayerId", playerName)
-            print("get {} playerid={}".format(playerName, playerId))
-
-        return Minecraft(conn, playerName)
+        return Minecraft(Connection(address, port, debug), playerName)
 
 
 def mcpy(func):

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -274,7 +274,7 @@ class Minecraft:
         return ids.split("|")
 
     def getPlayerEntityId(self, name):
-        """Get the entity id of the named player => [id:int]"""
+        """Get the entity id of the named player => id"""
         return self.conn.sendReceive(b"world.getPlayerId", name)
 
     def saveCheckpoint(self):

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -299,7 +299,13 @@ class Minecraft:
         self.conn.send(b"world.setting", setting, 1 if bool(status) else 0)
 
     def setPlayer(self, name):
+        """Set the current player"""
         return self.conn.sendReceive(b"setPlayer", name)
+
+    def getPlayerName(self):
+        """Get the name of the current player => str"""
+        playerName = self.conn.sendReceive(b"getPlayer")
+        return None if playerName == "(none)" else playerName
 
     @staticmethod
     def create(address="localhost", port=4711, playerName=[], debug=False):

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -39,8 +39,7 @@ class CmdPositioner:
 
     def getPos(self, id):
         """Get entity position (entityId:int) => Vec3"""
-        s = self.conn.sendReceive(self.pkg + b".getPos", id)
-        return Vec3(*list(map(float, s.split(","))))
+        return self._parseVec3(float, self.conn.sendReceive(self.pkg + b".getPos", id))
 
     def setPos(self, id, *args):
         """Set entity position (entityId:int, x,y,z)"""
@@ -48,8 +47,7 @@ class CmdPositioner:
 
     def getTilePos(self, id):
         """Get entity tile position (entityId:int) => Vec3"""
-        s = self.conn.sendReceive(self.pkg + b".getTile", id)
-        return Vec3(*list(map(int, s.split(","))))
+        return self._parseVec3(int, self.conn.sendReceive(self.pkg + b".getTile", id))
 
     def setTilePos(self, id, *args):
         """Set entity tile position (entityId:int) => Vec3"""
@@ -61,8 +59,7 @@ class CmdPositioner:
 
     def getDirection(self, id):
         """Get entity direction (entityId:int) => Vec3"""
-        s = self.conn.sendReceive(self.pkg + b".getDirection", id)
-        return Vec3(*map(float, s.split(",")))
+        return self._parseVec3(float, self.conn.sendReceive(self.pkg + b".getDirection", id))
 
     def setRotation(self, id, yaw):
         """Set entity rotation (entityId:int, yaw)"""
@@ -70,7 +67,7 @@ class CmdPositioner:
 
     def getRotation(self, id):
         """get entity rotation (entityId:int) => float"""
-        return float(self.conn.sendReceive(self.pkg + b".getRotation", id))
+        return self._parseScalar(float, self.conn.sendReceive(self.pkg + b".getRotation", id))
 
     def setPitch(self, id, pitch):
         """Set entity pitch (entityId:int, pitch)"""
@@ -78,11 +75,25 @@ class CmdPositioner:
 
     def getPitch(self, id):
         """get entity pitch (entityId:int) => float"""
-        return float(self.conn.sendReceive(self.pkg + b".getPitch", id))
+        return self._parseScalar(float, self.conn.sendReceive(self.pkg + b".getPitch", id))
 
     def setting(self, setting, status):
         """Set a player setting (setting, status). keys: autojump"""
         self.conn.send(self.pkg + b".setting", setting, 1 if bool(status) else 0)
+
+    @staticmethod
+    def _parseScalar(converter, string):
+        try:
+            return converter(string)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _parseVec3(converter, string):
+        try:
+            return Vec3(*list(map(converter, string.split(","))))
+        except ValueError:
+            return None
 
 class CmdEntity(CmdPositioner):
     """Methods for entities"""

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -214,7 +214,7 @@ class Minecraft:
         self.entity = CmdEntity(connection)
         self.player = CmdPlayer(connection, playerName)
         self.events = CmdEvents(connection)
-        self.playerName = playerName
+        self._playerName = playerName
 
     def getBlock(self, *args):
         """Get block (x,y,z) => id:int"""
@@ -301,18 +301,20 @@ class Minecraft:
     def setPlayer(self, name):
         """Set the current player => bool"""
         if self.conn.sendReceive(b"setPlayer", name):
-            self.playerName = name
+            self._playerName = name
             return True
         else:
             return False
 
     def getPlayerName(self):
         """Get the name of the previously set / currently attached player => str"""
-        if self.playerName:
-            return self.playerName
+        if self._playerName:
+            return self._playerName
         else:
-            playerName = self.conn.sendReceive(b"getPlayer")
-            return None if playerName == "(none)" else playerName
+            p = self.conn.sendReceive(b"getPlayer")
+            return None if p == "(none)" else p
+
+    playerName = property(getPlayerName)
 
     @staticmethod
     def create(address="localhost", port=4711, playerName=[], debug=False):

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -278,9 +278,9 @@ class Minecraft:
         return self.conn.sendReceive(b"world.getPlayerId", name)
 
     def getPlayerNames(self):
-        """Get the names of all currently connected players => [str]"""
+        """Get the names of all currently connected players (or an empty List) => [str]"""
         ids = self.conn.sendReceive(b"world.getPlayerIds")
-        return [tuple.split(":")[0] for tuple in ids.split("|")]
+        return [] if not ids else [tuple.split(":")[0] for tuple in ids.split("|")]
 
     def saveCheckpoint(self):
         """Save a checkpoint that can be used for restoring the world"""


### PR DESCRIPTION
* Note: This is being integrated via ResilientGroup/JuicyRaspberryPie#2

from the mcpi-e package (cp. stoneskin/mcpi-e@fd0238b):
- `CmdPlayer` gets the `playerId` injected
- `Minecraft.create()` now takes an optional playerName argument, defaulting to `[]` for the original behavior of choosing the first player on the server
- Discard the added `CmdPlayerEntity` class; `JuicyRaspberryPie` needs `player.*` commands; it doesn't work when `entity.*` commands are sent for a player. Likewise, don't include the (anyway confusing) distinction between `Minecraft.player` and `Minecraft.cmdplayer`.
- JuicyRaspberryPie actually takes the player's name, not the resolved UUID.

* Add `Minecraft.getPlayerNames()`; as the JuicyRaspberryPie API takes player names, the `name:UUID` combinations returned by `Minecraft.getPlayerEntityIds()` are not very useful (and require further parsing by the client).
* Add `Minecraft.getPlayerName()`

JuicyRaspberryPie has a notion of attachedPlayer that is set by `setPlayer()` and defaults to the first active user when the connection is established.
Let's implement this logic: If no player is passed to mcpi, use that first active user; if that user leaves, switch to another available user (or fail when noone's there).
If a player is passed or later set via `Minecraft.setPlayer()`, the instance will be linked to that. If that player leaves, any player-related calls will fail until the player returns.