### PR TITLE
TASK-4024 BUG: Minecraft.getNearbyEntities() throws ValueError

### DIFF
--- a/mcpi/connection.py
+++ b/mcpi/connection.py
@@ -53,3 +53,11 @@ class Connection:
         """Sends and receive data"""
         self._send(*data)
         return self._receive()
+
+    def sendReceiveList(self, *data):
+        """Send data and receive a List of items."""
+        self._send(*data)
+        return self._unmarshalList(self._receive())
+
+    def _unmarshalList(self, dataStr):
+        return [] if not dataStr else [item for item in dataStr.split("|")]

--- a/mcpi/event.py
+++ b/mcpi/event.py
@@ -27,8 +27,9 @@ class ChatEvent:
     """An Event related to chat (e.g. posts)"""
     POST = 0
 
-    def __init__(self, type, entityId, message):
+    def __init__(self, type, name, entityId, message):
         self.type = type
+        self.name = name
         self.entityId = entityId
         self.message = message
 
@@ -37,12 +38,12 @@ class ChatEvent:
             ChatEvent.POST: "ChatEvent.POST"
         }.get(self.type, "???")
 
-        return "ChatEvent(%s, %d, %s)" % (
-            sType, self.entityId, self.message)
+        return "ChatEvent(%s, %s:%s, %s)" % (
+            sType, self.name, self.entityId, self.message)
 
     @staticmethod
-    def Post(entityId, message):
-        return ChatEvent(ChatEvent.POST, int(entityId), message)
+    def Post(name, entityId, message):
+        return ChatEvent(ChatEvent.POST, name, entityId, message)
 
 
 class ProjectileEvent:

--- a/mcpi/event.py
+++ b/mcpi/event.py
@@ -42,7 +42,7 @@ class ChatEvent:
 
     @staticmethod
     def Post(entityId, message):
-        return ChatEvent(ChatEvent.POST, entityId, message)
+        return ChatEvent(ChatEvent.POST, int(entityId), message)
 
 
 class ProjectileEvent:

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -202,7 +202,7 @@ class CmdEvents:
     def pollChatPosts(self):
         """Triggered by posts to chat => [ChatEvent]"""
         events = self.conn.sendReceiveList(b"events.chat.posts")
-        return [ChatEvent.Post(int(e[:e.find(",")]), e[e.find(",") + 1:]) for e in events]
+        return [ChatEvent.Post(e[:e.find(",")], e[e.find(",") + 1:]) for e in events]
 
     def pollProjectileHits(self):
         """Only triggered by projectiles => [BlockEvent]"""

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -202,7 +202,7 @@ class CmdEvents:
     def pollChatPosts(self):
         """Triggered by posts to chat => [ChatEvent]"""
         events = self.conn.sendReceiveList(b"events.chat.posts")
-        return [ChatEvent.Post(e[:e.find(",")], e[e.find(",") + 1:]) for e in events]
+        return [ChatEvent.Post(*e.split(",", 1)) for e in events]
 
     def pollProjectileHits(self):
         """Only triggered by projectiles => [BlockEvent]"""

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -102,10 +102,10 @@ class CmdEntity(CmdPositioner):
 
 
 class Entity:
-    def __init__(self, conn, entity_uuid, typeName):
+    def __init__(self, conn, typeName, entity_uuid):
         self.p = CmdEntity(conn)
-        self.id = entity_uuid
         self.type = typeName
+        self.id = entity_uuid
     def getPos(self):
         return self.p.getPos(self.id)
     def setPos(self, *args):
@@ -258,7 +258,7 @@ class Minecraft:
 
     def spawnEntity(self, *args):
         """Spawn entity (x,y,z,id,[data])"""
-        return Entity(self.conn, self.conn.sendReceive(b"world.spawnEntity", *args), args[3])
+        return Entity(self.conn, args[3], self.conn.sendReceive(b"world.spawnEntity", *args))
 
     def spawnParticle(self, *args):
         """Spawn entity (x,y,z,id,[data])"""
@@ -268,8 +268,7 @@ class Minecraft:
         """get nearby entities (x,y,z)"""
         entities = []
         for i in self.conn.sendReceive(b"world.getNearbyEntities", *args).split("|"):
-            name, eid = i.split(":")
-            entities.append(Entity(self.conn, eid, name))
+            entities.append(Entity(self.conn, *i.split(":")))
         return entities
 
     def removeEntity(self, *args):

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -196,20 +196,17 @@ class CmdEvents:
 
     def pollBlockHits(self):
         """Only triggered by sword => [BlockEvent]"""
-        s = self.conn.sendReceive(b"events.block.hits")
-        events = [e for e in s.split("|") if e]
+        events = self.conn.sendReceiveList(b"events.block.hits")
         return [BlockEvent.Hit(*e.split(",")) for e in events]
 
     def pollChatPosts(self):
         """Triggered by posts to chat => [ChatEvent]"""
-        s = self.conn.sendReceive(b"events.chat.posts")
-        events = [e for e in s.split("|") if e]
+        events = self.conn.sendReceiveList(b"events.chat.posts")
         return [ChatEvent.Post(int(e[:e.find(",")]), e[e.find(",") + 1:]) for e in events]
 
     def pollProjectileHits(self):
         """Only triggered by projectiles => [BlockEvent]"""
-        s = self.conn.sendReceive(b"events.projectile.hits")
-        events = [e for e in s.split("|") if e]
+        events = self.conn.sendReceiveList(b"events.projectile.hits")
         return [ProjectileEvent.Hit(*e.split(",")) for e in events]
 
 
@@ -267,7 +264,7 @@ class Minecraft:
     def getNearbyEntities(self, *args):
         """get nearby entities (x,y,z)"""
         entities = []
-        for i in self.conn.sendReceive(b"world.getNearbyEntities", *args).split("|"):
+        for i in self.conn.sendReceiveList(b"world.getNearbyEntities", *args):
             entities.append(Entity(self.conn, *i.split(":")))
         return entities
 
@@ -281,8 +278,7 @@ class Minecraft:
 
     def getPlayerEntityIds(self):
         """Get the entity ids of the connected players => [id:int]"""
-        ids = self.conn.sendReceive(b"world.getPlayerIds")
-        return ids.split("|")
+        return self.conn.sendReceiveList(b"world.getPlayerIds")
 
     def getPlayerEntityId(self, name):
         """Get the entity id of the named player => id"""
@@ -290,8 +286,8 @@ class Minecraft:
 
     def getPlayerNames(self):
         """Get the names of all currently connected players (or an empty List) => [str]"""
-        ids = self.conn.sendReceive(b"world.getPlayerIds")
-        return [] if not ids else [tuple.split(":")[0] for tuple in ids.split("|")]
+        ids = self.conn.sendReceiveList(b"world.getPlayerIds")
+        return [] if not ids else [tuple.split(":")[0] for tuple in ids]
 
     def saveCheckpoint(self):
         """Save a checkpoint that can be used for restoring the world"""

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -267,7 +267,7 @@ class Minecraft:
     def getNearbyEntities(self, *args):
         """get nearby entities (x,y,z)"""
         entities = []
-        for i in self.conn.sendReceive(b"world.getNearbyEntities", *args).split(","):
+        for i in self.conn.sendReceive(b"world.getNearbyEntities", *args).split("|"):
             name, eid = i.split(":")
             entities.append(Entity(self.conn, eid, name))
         return entities

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -202,7 +202,7 @@ class CmdEvents:
     def pollChatPosts(self):
         """Triggered by posts to chat => [ChatEvent]"""
         events = self.conn.sendReceiveList(b"events.chat.posts")
-        return [ChatEvent.Post(*e.split(",", 1)) for e in events]
+        return [ChatEvent.Post(*e.split(",", 2)) for e in events]
 
     def pollProjectileHits(self):
         """Only triggered by projectiles => [BlockEvent]"""


### PR DESCRIPTION
JuicyRaspberryPie [dc877e6..37c7a93](https://github.com/ResilientGroup/JuicyRaspberryPie/compare/dc877e6...37c7a93):
* TASK-4024 FIX: ChatEvent.Post contains entityId(int) that is used nowhere else
* TASK-4024 Consistency: Use | instead of , for delimiting individual entities

Use a consistent `|` delimiter for delimiting individual entities  

Add `Connection.sendReceiveList()` variant of `sendReceive()` for the common case of receiving a (`|`-delimited) List of items.

This also addresses the following additional issues:  
- `Minecraft.getPlayerEntityIds()` returns `['']` instead of `[]` when there's no Player online.
- The `CmdEvents.poll*()` methods accepted not just completely empty data, but also hid empty items (`one||three`). The server should not send empty items, or if it does, these empty ones should also have a meaning for the client. I don't think this behavior was intentional, but rather a side effect of the used list comprehension.

FIX: `ChatEvent.Post` contains `entityId(int)` that is used nowhere else

It makes more sense to return the Player's name and UUID, as that's what methods like `Minecraft.getPlayerName[s]()` and `Minecraft.getPlayerEntityId[s]()` return as well. Remove the `int()` conversion for entityId and add an additional name attribute.

Server: `rebuild-task-4024-bug-getnearbyentities-w.dev-join.reload.works`