### PR TITLE
TASK-4017 Refactoring: Move to a higher-level, typed Connection interface with less duplication

### DIFF
--- a/mcpi/connection.py
+++ b/mcpi/connection.py
@@ -71,7 +71,7 @@ class Connection:
         return self._parseVec3(converter, self._receive())
 
     def _unmarshalList(self, dataStr):
-        return [] if not dataStr else [item for item in dataStr.split("|")]
+        return [] if not dataStr else dataStr.split("|")
 
     def _parseScalar(self, converter, string):
         try:

--- a/mcpi/connection.py
+++ b/mcpi/connection.py
@@ -55,10 +55,11 @@ class Connection:
         self._send(*data)
         return self._receive()
 
-    def sendReceiveList(self, *data):
+    def sendReceiveList(self, *data, **kwargs):
         """Send data and receive a List of items."""
         self._send(*data)
-        return self._unmarshalList(self._receive())
+        kwargs.setdefault("sep", "|")
+        return self._unmarshalList(self._receive(), **kwargs)
 
     def sendReceiveScalar(self, converter, *data):
         """Send data and receive a single item converted to the passed type."""
@@ -70,8 +71,8 @@ class Connection:
         self._send(*data)
         return self._parseVec3(converter, self._receive())
 
-    def _unmarshalList(self, dataStr):
-        return [] if not dataStr else dataStr.split("|")
+    def _unmarshalList(self, dataStr, **kwargs):
+        return [] if not dataStr else dataStr.split(**kwargs)
 
     def _parseScalar(self, converter, string):
         try:

--- a/mcpi/connection.py
+++ b/mcpi/connection.py
@@ -59,5 +59,16 @@ class Connection:
         self._send(*data)
         return self._unmarshalList(self._receive())
 
+    def sendReceiveScalar(self, converter, *data):
+        """Send data and receive a single item converted to the passed type."""
+        self._send(*data)
+        return self._parseScalar(converter, self._receive())
+
     def _unmarshalList(self, dataStr):
         return [] if not dataStr else [item for item in dataStr.split("|")]
+
+    def _parseScalar(self, converter, string):
+        try:
+            return converter(string)
+        except ValueError:
+            return None

--- a/mcpi/connection.py
+++ b/mcpi/connection.py
@@ -71,6 +71,10 @@ class Connection:
         self._send(*data)
         return self._parseVec3(converter, self._receive())
 
+    def sendReceiveObjectList(self, constructor, *data, **kwargs):
+        """Send data and receive a List of objects created by passing the received attributes to constructor."""
+        return [constructor(*o.split(",", **kwargs)) for o in (self.sendReceiveList(*data))]
+
     def _unmarshalList(self, dataStr, **kwargs):
         return [] if not dataStr else dataStr.split(**kwargs)
 

--- a/mcpi/connection.py
+++ b/mcpi/connection.py
@@ -2,6 +2,7 @@ import socket
 import select
 import sys
 from .util import flatten_parameters_to_bytestring
+from .vec3 import Vec3
 
 """ @author: Aron Nieminen, Mojang AB"""
 
@@ -64,11 +65,22 @@ class Connection:
         self._send(*data)
         return self._parseScalar(converter, self._receive())
 
+    def sendReceiveVec3(self, converter, *data):
+        """Send data and receive a Vec3, with each coordinate converted to the passed type."""
+        self._send(*data)
+        return self._parseVec3(converter, self._receive())
+
     def _unmarshalList(self, dataStr):
         return [] if not dataStr else [item for item in dataStr.split("|")]
 
     def _parseScalar(self, converter, string):
         try:
             return converter(string)
+        except ValueError:
+            return None
+
+    def _parseVec3(self, converter, string):
+        try:
+            return Vec3(*list(map(converter, string.split(","))))
         except ValueError:
             return None

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -2,7 +2,6 @@ import os
 import math
 
 from .connection import Connection
-from .vec3 import Vec3
 from .event import BlockEvent, ChatEvent, ProjectileEvent
 from .util import flatten
 
@@ -18,7 +17,7 @@ class CmdPositioner:
 
     def getPos(self, id):
         """Get entity position (entityId:int) => Vec3"""
-        return self._parseVec3(float, self.conn.sendReceive(self.pkg + b".getPos", id))
+        return self.conn.sendReceiveVec3(float, self.pkg + b".getPos", id)
 
     def setPos(self, id, *args):
         """Set entity position (entityId:int, x,y,z)"""
@@ -26,7 +25,7 @@ class CmdPositioner:
 
     def getTilePos(self, id):
         """Get entity tile position (entityId:int) => Vec3"""
-        return self._parseVec3(int, self.conn.sendReceive(self.pkg + b".getTile", id))
+        return self.conn.sendReceiveVec3(int, self.pkg + b".getTile", id)
 
     def setTilePos(self, id, *args):
         """Set entity tile position (entityId:int) => Vec3"""
@@ -38,7 +37,7 @@ class CmdPositioner:
 
     def getDirection(self, id):
         """Get entity direction (entityId:int) => Vec3"""
-        return self._parseVec3(float, self.conn.sendReceive(self.pkg + b".getDirection", id))
+        return self.conn.sendReceiveVec3(float, self.pkg + b".getDirection", id)
 
     def setRotation(self, id, yaw):
         """Set entity rotation (entityId:int, yaw)"""
@@ -59,13 +58,6 @@ class CmdPositioner:
     def setting(self, setting, status):
         """Set a player setting (setting, status). keys: autojump"""
         self.conn.sendReceive(self.pkg + b".setting", setting, 1 if bool(status) else 0)
-
-    @staticmethod
-    def _parseVec3(converter, string):
-        try:
-            return Vec3(*list(map(converter, string.split(","))))
-        except ValueError:
-            return None
 
 class CmdEntity(CmdPositioner):
     """Methods for entities"""

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -247,7 +247,7 @@ class Minecraft:
     def getNearbyEntities(self, *args):
         """get nearby entities (x,y,z)"""
         entities = self.conn.sendReceiveList(b"world.getNearbyEntities", *args)
-        return [Entity(self.conn, *e.split(":")) for e in entities]
+        return [Entity(self.conn, *e.split(",")) for e in entities]
 
     def removeEntity(self, *args):
         """Spawn entity (x,y,z,id,[data])"""
@@ -260,7 +260,7 @@ class Minecraft:
     def getPlayerEntityIds(self):
         """Get the entity ids of the connected players => [id]"""
         ids = self.conn.sendReceiveList(b"world.getPlayerIds")
-        return [] if not ids else [tuple.split(":")[1] for tuple in ids]
+        return [] if not ids else [tuple.split(",")[1] for tuple in ids]
 
     def getPlayerEntityId(self, name):
         """Get the entity id of the named player => id"""
@@ -269,7 +269,7 @@ class Minecraft:
     def getPlayerNames(self):
         """Get the names of all currently connected players (or an empty List) => [str]"""
         ids = self.conn.sendReceiveList(b"world.getPlayerIds")
-        return [] if not ids else [tuple.split(":")[0] for tuple in ids]
+        return [] if not ids else [tuple.split(",")[0] for tuple in ids]
 
     def saveCheckpoint(self):
         """Save a checkpoint that can be used for restoring the world"""

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -246,10 +246,8 @@ class Minecraft:
 
     def getNearbyEntities(self, *args):
         """get nearby entities (x,y,z)"""
-        entities = []
-        for i in self.conn.sendReceiveList(b"world.getNearbyEntities", *args):
-            entities.append(Entity(self.conn, *i.split(":")))
-        return entities
+        entities = self.conn.sendReceiveList(b"world.getNearbyEntities", *args)
+        return [Entity(self.conn, *e.split(":")) for e in entities]
 
     def removeEntity(self, *args):
         """Spawn entity (x,y,z,id,[data])"""

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -46,7 +46,7 @@ class CmdPositioner:
 
     def getRotation(self, id):
         """get entity rotation (entityId:int) => float"""
-        return self._parseScalar(float, self.conn.sendReceive(self.pkg + b".getRotation", id))
+        return self.conn.sendReceiveScalar(float, self.pkg + b".getRotation", id)
 
     def setPitch(self, id, pitch):
         """Set entity pitch (entityId:int, pitch)"""
@@ -54,18 +54,11 @@ class CmdPositioner:
 
     def getPitch(self, id):
         """get entity pitch (entityId:int) => float"""
-        return self._parseScalar(float, self.conn.sendReceive(self.pkg + b".getPitch", id))
+        return self.conn.sendReceiveScalar(float, self.pkg + b".getPitch", id)
 
     def setting(self, setting, status):
         """Set a player setting (setting, status). keys: autojump"""
         self.conn.sendReceive(self.pkg + b".setting", setting, 1 if bool(status) else 0)
-
-    @staticmethod
-    def _parseScalar(converter, string):
-        try:
-            return converter(string)
-        except ValueError:
-            return None
 
     @staticmethod
     def _parseVec3(converter, string):

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -216,9 +216,7 @@ class Minecraft:
 
     def getBlocks(self, *args):
         """Get a cuboid of blocks (x0,y0,z0,x1,y1,z1) => [id:int]"""
-        # s = self.conn.sendReceive(b"world.getBlocks", intFloor(args))
-        s = self.conn.sendReceive(b"world.getBlocks", *args)
-        return s.split(",")
+        return self.conn.sendReceive(b"world.getBlocks", *args).split(",")
 
     def setBlock(self, *args):
         """Set block (x,y,z,id,[data])"""

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -181,18 +181,15 @@ class CmdEvents:
 
     def pollBlockHits(self):
         """Only triggered by sword => [BlockEvent]"""
-        events = self.conn.sendReceiveList(b"events.block.hits")
-        return [BlockEvent.Hit(*e.split(",")) for e in events]
+        return self.conn.sendReceiveObjectList(BlockEvent.Hit, b"events.block.hits")
 
     def pollChatPosts(self):
         """Triggered by posts to chat => [ChatEvent]"""
-        events = self.conn.sendReceiveList(b"events.chat.posts")
-        return [ChatEvent.Post(*e.split(",", 2)) for e in events]
+        return self.conn.sendReceiveObjectList(ChatEvent.Post, b"events.chat.posts", maxsplit=2)
 
     def pollProjectileHits(self):
         """Only triggered by projectiles => [BlockEvent]"""
-        events = self.conn.sendReceiveList(b"events.projectile.hits")
-        return [ProjectileEvent.Hit(*e.split(",")) for e in events]
+        return self.conn.sendReceiveObjectList(ProjectileEvent.Hit, b"events.projectile.hits")
 
 
 class Minecraft:
@@ -246,8 +243,8 @@ class Minecraft:
 
     def getNearbyEntities(self, *args):
         """get nearby entities (x,y,z)"""
-        entities = self.conn.sendReceiveList(b"world.getNearbyEntities", *args)
-        return [Entity(self.conn, *e.split(",")) for e in entities]
+        return self.conn.sendReceiveObjectList(
+            lambda *attr: Entity(self.conn, *attr), b"world.getNearbyEntities", *args)
 
     def removeEntity(self, *args):
         """Spawn entity (x,y,z,id,[data])"""
@@ -259,8 +256,7 @@ class Minecraft:
 
     def getPlayerEntityIds(self):
         """Get the entity ids of the connected players => [id]"""
-        ids = self.conn.sendReceiveList(b"world.getPlayerIds")
-        return [] if not ids else [tuple.split(",")[1] for tuple in ids]
+        return self.conn.sendReceiveObjectList(lambda name, entityId: entityId, b"world.getPlayerIds")
 
     def getPlayerEntityId(self, name):
         """Get the entity id of the named player => id"""
@@ -268,8 +264,7 @@ class Minecraft:
 
     def getPlayerNames(self):
         """Get the names of all currently connected players (or an empty List) => [str]"""
-        ids = self.conn.sendReceiveList(b"world.getPlayerIds")
-        return [] if not ids else [tuple.split(",")[0] for tuple in ids]
+        return self.conn.sendReceiveObjectList(lambda name, entityId: name, b"world.getPlayerIds")
 
     def saveCheckpoint(self):
         """Save a checkpoint that can be used for restoring the world"""

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -212,11 +212,11 @@ class Minecraft:
 
     def getBlockWithData(self, *args):
         """Get block with data (x,y,z) => Block"""
-        return self.conn.sendReceive(b"world.getBlockWithData", _intFloor(args)).split(",")
+        return self.conn.sendReceiveList(b"world.getBlockWithData", _intFloor(args), sep=",")
 
     def getBlocks(self, *args):
         """Get a cuboid of blocks (x0,y0,z0,x1,y1,z1) => [id:int]"""
-        return self.conn.sendReceive(b"world.getBlocks", *args).split(",")
+        return self.conn.sendReceiveList(b"world.getBlocks", *args, sep=",")
 
     def setBlock(self, *args):
         """Set block (x,y,z,id,[data])"""

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -6,7 +6,7 @@ from .event import BlockEvent, ChatEvent, ProjectileEvent
 from .util import flatten
 
 
-def intFloor(*args):
+def _intFloor(*args):
     return [int(math.floor(x)) for x in flatten(args)]
 
 class CmdPositioner:
@@ -29,7 +29,7 @@ class CmdPositioner:
 
     def setTilePos(self, id, *args):
         """Set entity tile position (entityId:int) => Vec3"""
-        self.conn.sendReceive(self.pkg + b".setTile", id, intFloor(*args))
+        self.conn.sendReceive(self.pkg + b".setTile", id, _intFloor(*args))
 
     def setDirection(self, id, *args):
         """Set entity direction (entityId:int, x,y,z)"""
@@ -208,11 +208,11 @@ class Minecraft:
 
     def getBlock(self, *args):
         """Get block (x,y,z) => id:int"""
-        return self.conn.sendReceive(b"world.getBlock", intFloor(args))
+        return self.conn.sendReceive(b"world.getBlock", _intFloor(args))
 
     def getBlockWithData(self, *args):
         """Get block with data (x,y,z) => Block"""
-        return self.conn.sendReceive(b"world.getBlockWithData", intFloor(args)).split(",")
+        return self.conn.sendReceive(b"world.getBlockWithData", _intFloor(args)).split(",")
 
     def getBlocks(self, *args):
         """Get a cuboid of blocks (x0,y0,z0,x1,y1,z1) => [id:int]"""
@@ -259,7 +259,7 @@ class Minecraft:
 
     def getHeight(self, *args):
         """Get the height of the world (x,z) => int"""
-        return int(self.conn.sendReceive(b"world.getHeight", intFloor(args)))
+        return int(self.conn.sendReceive(b"world.getHeight", _intFloor(args)))
 
     def getPlayerEntityIds(self):
         """Get the entity ids of the connected players => [id:int]"""

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -258,8 +258,9 @@ class Minecraft:
         return int(self.conn.sendReceive(b"world.getHeight", _intFloor(args)))
 
     def getPlayerEntityIds(self):
-        """Get the entity ids of the connected players => [id:int]"""
-        return self.conn.sendReceiveList(b"world.getPlayerIds")
+        """Get the entity ids of the connected players => [id]"""
+        ids = self.conn.sendReceiveList(b"world.getPlayerIds")
+        return [] if not ids else [tuple.split(":")[1] for tuple in ids]
 
     def getPlayerEntityId(self, name):
         """Get the entity id of the named player => id"""


### PR DESCRIPTION
JuicyRaspberryPie [26468c9..a63e99a](https://github.com/ResilientGroup/JuicyRaspberryPie/compare/26468c9...a63e99a):
* TASK-4017 Consistency: Separate entity ID, name also with comma, not colon

The various methods that receive a List still use inconsistent separators; `CmdEvents.poll*()` use items separated by `|` and individual attributes separated by `,`; let's use that as the norm. `,` is as good (or bad) with regard to escaping as `:`.

Each mcpi method already uses `Connection.sendReceiveList()`, but still does the splitting of a single object's marshaled representation itself. Add a `Connection.sendReceiveObjectList()` that does that and returns a list of constructed objects.

The helpers `CmdPositioner._parseVec3()` and `CmdPositioner._parseScalar()` have nothing to do with `CmdPositioner`; it's just that they are used there right now. Move those to `Connection` and combine their parsing with the send-receive.

Server: `rebuild-task-4017-refactoring-world-proto.dev-join.reload.works`