### PR TITLE
mcpi: Regression: CmdEntity errors

### DIFF
--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -76,8 +76,8 @@ class Entity(CmdPositioner):
         """Move entity (entityId:int, x,y,z)"""
         self.conn.sendReceive(self.pkg + b".walkTo", self.entityID, args)
 
-    def remove(self, id):
-        self.conn.sendReceive(b"entity.remove", id)
+    def remove(self):
+        self.conn.sendReceive(b"entity.remove", self.entityID)
 
 
 class Player(CmdPositioner):

--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -15,7 +15,7 @@ class CmdPositioner:
 
     def getName(self):
         """Get entity name (entityId:int) => str"""
-        return self.conn.sendReceive(b"entity.getName", id)
+        return self.conn.sendReceive(b"entity.getName", self.entityID)
 
     def getPos(self):
         """Get entity position (entityId:int) => Vec3"""


### PR DESCRIPTION
* `CmdEntity.remove()` still requires `id` argument
* `CmdEntity.getName()` references global function `id()`

Found during exploratory testing of the mcpi API. The `ID` is now stored in the super class's `entityID` attribute.  

---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
  - [X] `mc.getNearbyEntities(mc.player.getPos())[0].getName()` does not complain about `id` any longer
  - [X] `mc.getNearbyEntities(mc.player.getPos())[0].remove()` does not complain about `id` any longer
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] ~~Classes and public methods have documentation (that doesn't just repeat the technical subject in English)~~
- [ ] ~~Logging is implemented to monitor feature usage and troubleshoot problems in production~~
- [ ] ~~These ReWiki pages are affected by this change and will be adapted:~~