### PR TITLE
Documentation: Review mcpi API signatures and convert comments to type annotations

### DIFF
--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -1,6 +1,8 @@
 import os
 from enum import Enum
+from typing import Union, overload, List, Optional, Tuple
 
+from mcpi.vec3 import Vec3
 from .connection import Connection
 from .event import BlockEvent, ChatEvent, ProjectileEvent
 
@@ -13,48 +15,66 @@ class CmdPositioner:
         self.pkg = packagePrefix
         self.entityID = entityID
 
-    def getName(self):
-        """Get entity name (entityId:int) => str"""
+    def getName(self) -> str:
+        """Get entity name"""
         return self.conn.sendReceive(b"entity.getName", self.entityID)
 
-    def getPos(self):
-        """Get entity position (entityId:int) => Vec3"""
+    def getPos(self) -> Vec3:
+        """Get entity position"""
         return self.conn.sendReceiveVec3(float, self.pkg + b".getPos", self.entityID)
 
-    def setPos(self, *args):
-        """Set entity position (entityId:int, x,y,z)"""
+    @overload
+    def setPos(self, vec: Vec3) -> None: ...
+
+    @overload
+    def setPos(self, x: int, y: int, z: int) -> None: ...
+
+    def setPos(self, *args: Union[Vec3, int]) -> None:
+        """Set entity position"""
         self.conn.sendReceive(self.pkg + b".setPos", self.entityID, args)
 
-    def getTilePos(self):
-        """Get entity tile position (entityId:int) => Vec3"""
+    def getTilePos(self) -> Vec3:
+        """Get entity tile position"""
         return self.conn.sendReceiveVec3(int, self.pkg + b".getTile", self.entityID)
 
-    def setTilePos(self, *args):
-        """Set entity tile position (entityId:int) => Vec3"""
+    @overload
+    def setTilePos(self, vec: Vec3) -> None: ...
+
+    @overload
+    def setTilePos(self, x: int, y: int, z: int) -> None: ...
+
+    def setTilePos(self, *args: Union[Vec3, int]) -> None:
+        """Set entity tile position"""
         self.conn.sendReceive(self.pkg + b".setTile", self.entityID, *args)
 
-    def setDirection(self, *args):
-        """Set entity direction (entityId:int, x,y,z)"""
+    @overload
+    def setDirection(self, vec: Vec3) -> None: ...
+
+    @overload
+    def setDirection(self, x: int, y: int, z: int) -> None: ...
+
+    def setDirection(self, *args) -> None:
+        """Set entity direction"""
         self.conn.sendReceive(self.pkg + b".setDirection", self.entityID, args)
 
-    def getDirection(self):
-        """Get entity direction (entityId:int) => Vec3"""
+    def getDirection(self) -> Vec3:
+        """Get entity direction"""
         return self.conn.sendReceiveVec3(float, self.pkg + b".getDirection", self.entityID)
 
-    def setRotation(self, yaw):
+    def setRotation(self, yaw: float) -> None:
         """Set entity rotation (entityId:int, yaw)"""
         self.conn.sendReceive(self.pkg + b".setRotation", self.entityID, yaw)
 
-    def getRotation(self):
-        """get entity rotation (entityId:int) => float"""
+    def getRotation(self) -> float:
+        """Get entity rotation"""
         return self.conn.sendReceiveScalar(float, self.pkg + b".getRotation", self.entityID)
 
-    def setPitch(self, pitch):
-        """Set entity pitch (entityId:int, pitch)"""
+    def setPitch(self, pitch: float) -> None:
+        """Set entity pitch"""
         self.conn.sendReceive(self.pkg + b".setPitch", self.entityID, pitch)
 
-    def getPitch(self):
-        """get entity pitch (entityId:int) => float"""
+    def getPitch(self) -> float:
+        """get entity pitch"""
         return self.conn.sendReceiveScalar(float, self.pkg + b".getPitch", self.entityID)
 
 
@@ -64,19 +84,25 @@ class Entity(CmdPositioner):
         CmdPositioner.__init__(self, connection, b"entity", entityID)
         self.type = typeName
 
-    def enableControl(self):
-        """Enable control of entity (entityId:int)"""
+    def enableControl(self) -> None:
+        """Enable control of entity"""
         self.conn.sendReceive(self.pkg + b".enableControl", self.entityID)
 
-    def disableControl(self):
-        """Disable control of entity (entityId:int)"""
+    def disableControl(self) -> None:
+        """Disable control of entity"""
         self.conn.sendReceive(self.pkg + b".disableControl", self.entityID)
 
-    def walkTo(self, *args):
-        """Move entity (entityId:int, x,y,z)"""
+    @overload
+    def walkTo(self, vec: Vec3) -> None: ...
+
+    @overload
+    def walkTo(self, x: int, y: int, z: int) -> None: ...
+
+    def walkTo(self, *args: Union[Vec3, int]) -> None:
+        """Move entity"""
         self.conn.sendReceive(self.pkg + b".walkTo", self.entityID, args)
 
-    def remove(self):
+    def remove(self) -> None:
         self.conn.sendReceive(b"entity.remove", self.entityID)
 
 
@@ -111,8 +137,14 @@ class CmdCamera:
         """Set camera mode to follow an entity ([entityId])"""
         self.conn.sendReceive(b"camera.mode.setFollow", args)
 
-    def setPos(self, *args):
-        """Set camera entity position (x,y,z)"""
+    @overload
+    def setPos(self, vec: Vec3) -> None: ...
+
+    @overload
+    def setPos(self, x: int, y: int, z: int) -> None: ...
+
+    def setPos(self, *args: Union[Vec3, int]) -> None:
+        """Set camera entity position"""
         self.conn.sendReceive(b"camera.setPos", args)
 
 
@@ -122,20 +154,20 @@ class CmdEvents:
     def __init__(self, connection):
         self.conn = connection
 
-    def clearAll(self):
+    def clearAll(self) -> None:
         """Clear all old events"""
         self.conn.sendReceive(b"events.clear")
 
-    def pollBlockHits(self):
-        """Only triggered by sword => [BlockEvent]"""
+    def pollBlockHits(self) -> List[BlockEvent]:
+        """Only triggered by sword"""
         return self.conn.sendReceiveObjectList(BlockEvent.Hit, b"events.block.hits")
 
-    def pollChatPosts(self):
-        """Triggered by posts to chat => [ChatEvent]"""
+    def pollChatPosts(self) -> List[ChatEvent]:
+        """Triggered by posts to chat"""
         return self.conn.sendReceiveObjectList(ChatEvent.Post, b"events.chat.posts", maxsplit=2)
 
-    def pollProjectileHits(self):
-        """Only triggered by projectiles => [BlockEvent]"""
+    def pollProjectileHits(self) -> List[BlockEvent]:
+        """Only triggered by projectiles"""
         return self.conn.sendReceiveObjectList(ProjectileEvent.Hit, b"events.projectile.hits")
 
 
@@ -150,99 +182,205 @@ class Minecraft:
         self.events = CmdEvents(connection)
         self._playerName = playerName
 
-    def getBlock(self, *args):
-        """Get block (x,y,z) => id:int"""
+    @overload
+    def getBlock(self, vec: Vec3) -> str: ...
+
+    @overload
+    def getBlock(self, x: int, y: int, z: int) -> str: ...
+
+    def getBlock(self, *args: Union[Vec3, int]) -> str:
+        """Get block"""
         return self.conn.sendReceive(b"world.getBlock", args)
 
-    def getBlockWithData(self, *args):
-        """Get block with data (x,y,z) => Block"""
+    @overload
+    def getBlockWithData(self, vec: Vec3) -> Tuple[str, str]: ...
+
+    @overload
+    def getBlockWithData(self, x: int, y: int, z: int) -> Tuple[str, str]: ...
+
+    def getBlockWithData(self, *args: Union[Vec3, int]) -> Tuple[str, str]:
+        """Get block with data"""
         return self.conn.sendReceiveList(b"world.getBlockWithData", args, sep=",")
 
-    def getBlocks(self, *args):
-        """Get a cuboid of blocks (x0,y0,z0,x1,y1,z1) => [id:int]"""
+    @overload
+    def getBlocks(self, vec0: Vec3, vec1: Vec3) -> List[str]: ...
+
+    @overload
+    def getBlocks(self, x0: int, y0: int, z0: int, x1: int, y1: int, z1: int) -> List[str]: ...
+
+    def getBlocks(self, *args: Union[Vec3, int]) -> List[str]:
+        """Get a cuboid of blocks"""
         return self.conn.sendReceiveList(b"world.getBlocks", *args, sep=",")
 
-    def setBlock(self, *args):
-        """Set block (x,y,z,id,[data])"""
+    @overload
+    def setBlock(self, vec: Vec3, material: str, facing: int) -> None: ...
+    @overload
+    def setBlock(self, vec: Vec3, material: str) -> None: ...
+    @overload
+    def setBlock(self, vec: Vec3) -> None: ...
+
+    @overload
+    def setBlock(self, x: int, y: int, z: int, material: str, facing: int) -> None: ...
+    @overload
+    def setBlock(self, x: int, y: int, z: int, material: str) -> None: ...
+    @overload
+    def setBlock(self, x: int, y: int, z: int) -> None: ...
+
+    def setBlock(self, *args) -> None:
+        """Set block"""
         self.conn.sendReceive(b"world.setBlock", *args)
 
-    def setBlocks(self, *args):
-        """Set a cuboid of blocks (x0,y0,z0,x1,y1,z1,id,[data])"""
+    @overload
+    def setBlocks(self, vec0: Vec3, vec1: Vec3, material: str, facing: int) -> None: ...
+    @overload
+    def setBlocks(self, vec0: Vec3, vec1: Vec3, material: str) -> None: ...
+    @overload
+    def setBlocks(self, vec0: Vec3, vec1: Vec3) -> None: ...
+
+    @overload
+    def setBlocks(self, x0: int, y0: int, z0: int, x1: int, y1: int, z1: int, material: str, facing: int) -> None: ...
+    @overload
+    def setBlocks(self, x0: int, y0: int, z0: int, x1: int, y1: int, z1: int, material: str) -> None: ...
+    @overload
+    def setBlocks(self, x0: int, y0: int, z0: int, x1: int, y1: int, z1: int) -> None: ...
+
+    def setBlocks(self, *args) -> None:
+        """Set a cuboid of blocks"""
         self.conn.sendReceive(b"world.setBlocks", *args)
 
-    def isBlockPassable(self, *args):
-        """Check if block is passable (x,y,z) => Boolean"""
+    @overload
+    def isBlockPassable(self, vec: Vec3) -> bool: ...
+
+    @overload
+    def isBlockPassable(self, x: int, y: int, z: int) -> bool: ...
+
+    def isBlockPassable(self, *args: Union[Vec3, int]) -> bool:
+        """Check if block is passable"""
         return self.conn.sendReceiveBool(b"world.isBlockPassable", *args)
 
-    def setPowered(self, *args, state=PoweredState.TOGGLE):
-        """Set block powered (x,y,z,powered)"""
+    @overload
+    def setPowered(self, vec: Vec3, state: PoweredState) -> None: ...
+
+    @overload
+    def setPowered(self, x: int, y: int, z: int, state: PoweredState) -> None: ...
+
+    def setPowered(self, *args: Union[Vec3, int], state=PoweredState.TOGGLE) -> None:
+        """Set block powered"""
         self.conn.sendReceive(b"world.setPowered", *args, state)
 
-    def setSign(self, *args):
-        """Set a sign (x,y,z,sign_type,direction,line1,line2,line3,line4)
-        direction: 0-north, 1-east, 2-south 3-west
-        """
+    @overload
+    def setSign(self, vec: Vec3, material: Optional[str], facing: int, line1: str, line2: str, line3: str, line4: str) -> None: ...
+    @overload
+    def setSign(self, vec: Vec3, material: Optional[str], facing: int) -> None: ...
+    @overload
+    def setSign(self, vec: Vec3, material: Optional[str]) -> None: ...
+    @overload
+    def setSign(self, vec: Vec3) -> None: ...
+
+    @overload
+    def setSign(self, x: int, y: int, z: int, material: Optional[str], facing: int, line1: str, line2: str, line3: str, line4: str) -> None: ...
+    @overload
+    def setSign(self, x: int, y: int, z: int, material: Optional[str], facing: int) -> None: ...
+    @overload
+    def setSign(self, x: int, y: int, z: int, material: Optional[str]) -> None: ...
+    @overload
+    def setSign(self, x: int, y: int, z: int) -> None: ...
+
+    def setSign(self, *args) -> None:
+        """Set a sign"""
         self.conn.sendReceive(b"world.setSign", args)
 
-    def spawnEntity(self, *args):
-        """Spawn entity (x,y,z,id,[data])"""
+    @overload
+    def spawnEntity(self, vec: Vec3, entityType: str) -> None: ...
+    @overload
+    def spawnEntity(self, vec: Vec3) -> None: ...
+
+    @overload
+    def spawnEntity(self, x: int, y: int, z: int, entityType: str) -> None: ...
+    @overload
+    def spawnEntity(self, x: int, y: int, z: int) -> None: ...
+
+    def spawnEntity(self, *args) -> Entity:
+        """Spawn entity"""
         return Entity(self.conn, args[3], self.conn.sendReceive(b"world.spawnEntity", *args))
 
+    @overload
+    def spawnParticle(self, vec: Vec3, particleType: str) -> None: ...
+    @overload
+    def spawnParticle(self, vec: Vec3) -> None: ...
+
+    @overload
+    def spawnParticle(self, x: int, y: int, z: int, particleType: str) -> None: ...
+    @overload
+    def spawnParticle(self, x: int, y: int, z: int) -> None: ...
+
     def spawnParticle(self, *args):
-        """Spawn entity (x,y,z,id,[data])"""
+        """Spawn entity"""
         return self.conn.sendReceive(b"world.spawnParticle", *args)
 
-    def getNearbyEntities(self, *args):
-        """get nearby entities (x,y,z)"""
+    @overload
+    def getNearbyEntities(self, vec: Vec3) -> List[Entity]: ...
+
+    @overload
+    def getNearbyEntities(self, x: int, y: int, z: int) -> List[Entity]: ...
+
+    def getNearbyEntities(self, *args: Union[Vec3, int]) -> List[Entity]:
+        """Get nearby entities"""
         return self.conn.sendReceiveObjectList(
             lambda *attr: Entity(self.conn, *attr), b"world.getNearbyEntities", *args)
 
-    def removeEntity(self, *args):
-        """Spawn entity (x,y,z,id,[data])"""
+    def removeEntity(self, *args) -> None:
+        """Remove entity"""
         return self.conn.sendReceive(b"world.removeEntity", *args)
 
-    def getHeight(self, *args):
-        """Get the height of the world (x,y,z) => int"""
+    @overload
+    def getHeight(self, vec: Vec3) -> int: ...
+
+    @overload
+    def getHeight(self, x: int, y: int, z: int) -> int: ...
+
+    def getHeight(self, *args: Union[Vec3, int]) -> int:
+        """Get the height of the world"""
         return int(self.conn.sendReceive(b"world.getHeight", *args))
 
-    def getPlayerEntityIds(self):
-        """Get the entity ids of the connected players => [id]"""
+    def getPlayerEntityIds(self) -> List[str]:
+        """Get the entity ids of the connected players"""
         return self.conn.sendReceiveObjectList(lambda name, entityId: entityId, b"world.getPlayerIds")
 
-    def getPlayerEntityId(self, name):
-        """Get the entity id of the named player => id"""
+    def getPlayerEntityId(self, name: str) -> str:
+        """Get the entity id of the named player"""
         return self.conn.sendReceive(b"world.getPlayerId", name)
 
-    def getPlayerNames(self):
-        """Get the names of all currently connected players (or an empty List) => [str]"""
+    def getPlayerNames(self) -> List[str]:
+        """Get the names of all currently connected players (or an empty List)"""
         return self.conn.sendReceiveObjectList(lambda name, entityId: name, b"world.getPlayerIds")
 
-    def saveCheckpoint(self):
+    def saveCheckpoint(self) -> None:
         """Save a checkpoint that can be used for restoring the world"""
         self.conn.sendReceive(b"world.checkpoint.save")
 
-    def restoreCheckpoint(self):
+    def restoreCheckpoint(self) -> None:
         """Restore the world state to the checkpoint"""
         self.conn.sendReceive(b"world.checkpoint.restore")
 
-    def postToChat(self, msg):
+    def postToChat(self, msg: str) -> None:
         """Post a message to the game chat"""
         self.conn.sendReceive(b"chat.post", msg)
 
-    def setting(self, setting, status):
+    def setting(self, setting, status) -> None:
         """Set a world setting (setting, status). keys: world_immutable, nametags_visible"""
         self.conn.sendReceive(b"world.setting", setting, 1 if bool(status) else 0)
 
-    def setPlayer(self, name):
-        """Set the current player => bool"""
+    def setPlayer(self, name: str) -> bool:
+        """Set the current player"""
         if success := self.conn.sendReceiveBool(b"setPlayer", name):
             self._playerName = name
         else:
             self._playerName = None
         return success
 
-    def getPlayerName(self):
-        """Get the name of the previously set / currently attached player => str"""
+    def getPlayerName(self) -> Optional[str]:
+        """Get the name of the previously set / currently attached player"""
         if self._playerName:
             return self._playerName
         else:


### PR DESCRIPTION
There were some mistakes \(like copy-and-paste errors\), some outdated information \(references to int types from RaspberryJuice, wrong arguments from our refactoring\), and the types were just mentioned in non-standard comments, instead of using Python 3 type annotations.  

This enables better code completion in IDEs (or eventually even Jupyter).

* Note: This is a follow-up on #9

<!-- TODO: Please describe your changes here. -->

---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [X] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [X] No (significant) changes to production code
---
<!-- Documentation -->
- [X] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] ~~Logging is implemented to monitor feature usage and troubleshoot problems in production~~
- [ ] ~~These ReWiki pages are affected by this change and will be adapted:~~